### PR TITLE
Adding default value to Area element

### DIFF
--- a/templates/5ec1574d22999c4a5e8e0dc7/elements/Experimental/Charts/Area.tpl
+++ b/templates/5ec1574d22999c4a5e8e0dc7/elements/Experimental/Charts/Area.tpl
@@ -45,6 +45,6 @@ children: []
       legendType="{{ element.values.legendType|default('line') }}" 
       dataKey="{% if values.column_name %}{{ values.column_name }}{% else %}{{ element.values.valuesVariable }}{% endif %}" 
       stroke="{{ element.values.colors }}" 
-      fillOpacity={ {{ element.values.opacity }} } 
+      fillOpacity={ {{ element.values.opacity|default(1) }} } 
       fill="#{{ element.values.colors }}" 
     />


### PR DESCRIPTION
small fix, when Opacity is not defined now the default value is 1